### PR TITLE
Add null check for ConfigStore in BaseActivity

### DIFF
--- a/src/com/android/documentsui/BaseActivity.java
+++ b/src/com/android/documentsui/BaseActivity.java
@@ -504,6 +504,13 @@ public abstract class BaseActivity
                 getApplicationContext()
                         .getResources()
                         .getBoolean(R.bool.show_hidden_files_by_default));
+
+        if (mConfigStore == null) {
+            mConfigStore = DocumentsApplication.getConfigStore();
+            if (DEBUG) {
+                Log.d(mTag, "Created new config store object: " + mConfigStore);
+            }
+        }
         state.configStore = mConfigStore;
 
         includeState(state);


### PR DESCRIPTION
After the device has been on for a day or two, features such as copying or moving files from the com.android.documentsui (files) application randomly fail. 

if (SdkLevel.isAtLeastS() && mState.configStore.isPrivateSpaceInDocsUIEnabled()) {
mState = mActivity.getDisplayState();
mActivity = (BaseActivity) getActivity();

E AndroidRuntime: FATAL EXCEPTION: main
E AndroidRuntime: Process: com.android.documentsui, PID: 3506
E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke interface method 'boolean com.android.documentsui.ConfigStore.isPrivateSpaceInDocsUIEnabled()' on a null object reference
E AndroidRuntime: 	at com.android.documentsui.dirlist.DirectoryFragment.getModelBackedDocumentsAdapter(DirectoryFragment.java:660)
E AndroidRuntime: 	at com.android.documentsui.dirlist.DirectoryFragment.onActivityCreated(DirectoryFragment.java:522)
E AndroidRuntime: 	at androidx.fragment.app.Fragment.performActivityCreated(Fragment.java:3157)
E AndroidRuntime: 	at androidx.fragment.app.FragmentStateManager.activityCreated(FragmentStateManager.java:631)
E AndroidRuntime: 	at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:281)
E AndroidRuntime: 	at androidx.fragment.app.FragmentStore.moveToExpectedState(FragmentStore.java:114)
E AndroidRuntime: 	at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1663)
E AndroidRuntime: 	at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:3247)
E AndroidRuntime: 	at androidx.fragment.app.FragmentManager.dispatchActivityCreated(FragmentManager.java:3165)
E AndroidRuntime: 	at androidx.fragment.app.FragmentController.dispatchActivityCreated(FragmentController.java:263)
E AndroidRuntime: 	at androidx.fragment.app.FragmentActivity.onStart(FragmentActivity.java:350)
E AndroidRuntime: 	at androidx.appcompat.app.AppCompatActivity.onStart(AppCompatActivity.java:251)
E AndroidRuntime: 	at android.app.Instrumentation.callActivityOnStart(Instrumentation.java:1705)
E AndroidRuntime: 	at android.app.Activity.performStart(Activity.java:9045)
E AndroidRuntime: 	at android.app.ActivityThread.handleStartActivity(ActivityThread.java:4073)
E AndroidRuntime: 	at android.app.servertransaction.TransactionExecutor.performLifecycleSequence(TransactionExecutor.java:270)
E AndroidRuntime: 	at android.app.servertransaction.TransactionExecutor.cycleToPath(TransactionExecutor.java:250)
E AndroidRuntime: 	at android.app.servertransaction.TransactionExecutor.executeLifecycleItem(TransactionExecutor.java:222)
E AndroidRuntime: 	at android.app.servertransaction.TransactionExecutor.executeTransactionItems(TransactionExecutor.java:107)
E AndroidRuntime: 	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:81)
E AndroidRuntime: 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2636)
E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:107)
E AndroidRuntime: 	at android.os.Looper.loopOnce(Looper.java:232)
E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:317)
E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:8705)
E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:583)
E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:886)

I/ActivityTaskManager(1545): Displayed com.android.documentsui/.files.FilesActivity for user 0: +602ms
W/SelectionTracker(26269): Setting gestureTooltypes is likely to result in unexpected behavior.
W/ExternalStorage(26127): Error in checking file equality check.
W/ExternalStorage(26127): java.nio.file.NoSuchFileException: /storage/emulated
W/ExternalStorage(26127): 	at sun.nio.fs.UnixFileSystemProvider.isSameFile(UnixFileSystemProvider.java:344)
W/ExternalStorage(26127): 	at java.nio.file.Files.isSameFile(Files.java:1504)
W/ExternalStorage(26127): 	at com.android.externalstorage.ExternalStorageProvider.isRestrictedPath(ExternalStorageProvider.java:352)
W/ExternalStorage(26127): 	at com.android.externalstorage.ExternalStorageProvider.shouldHideDocument(ExternalStorageProvider.java:313)
W/ExternalStorage(26127): 	at com.android.externalstorage.ExternalStorageProvider.shouldBlockDirectoryFromTree(ExternalStorageProvider.java:415)
W/ExternalStorage(26127): 	at com.android.internal.content.FileSystemProvider.includeFile(FileSystemProvider.java:625)
W/ExternalStorage(26127): 	at com.android.internal.content.FileSystemProvider.queryChildDocuments(FileSystemProvider.java:422)
W/ExternalStorage(26127): 	at com.android.internal.content.FileSystemProvider.queryChildDocumentsForManage(FileSystemProvider.java:400)
W/ExternalStorage(26127): 	at android.provider.DocumentsProvider.query(DocumentsProvider.java:930)
W/ExternalStorage(26127): 	at android.content.ContentProvider$Transport.query(ContentProvider.java:295)
W/ExternalStorage(26127): 	at android.content.ContentProviderNative.onTransact(ContentProviderNative.java:107)
W/ExternalStorage(26127): 	at android.os.Binder.execTransactInternal(Binder.java:1500)
W/ExternalStorage(26127): 	at android.os.Binder.execTransact(Binder.java:1444)
W/ExternalStorage(26127): Error in checking file equality check.
W/ExternalStorage(26127): java.nio.file.NoSuchFileException: /storage/emulated